### PR TITLE
Fix failing Feature test by setting app key

### DIFF
--- a/api/phpunit.xml
+++ b/api/phpunit.xml
@@ -29,5 +29,6 @@
         <env name="QUEUE_CONNECTION" value="sync"/>
         <env name="SESSION_DRIVER" value="array"/>
         <env name="TELESCOPE_ENABLED" value="false"/>
+        <env name="APP_KEY" value="base64:1byShg2UKkJ71vj0AO+5arw6ItmaBJNy9CJhFJU2LV4="/>
     </php>
 </phpunit>


### PR DESCRIPTION
## Summary
- set `APP_KEY` in `phpunit.xml` to avoid `MissingAppKeyException`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_68468851d24483328db3ef9464c1f74b