### PR TITLE
feat: auto-generate APP_KEY on container start

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,7 +1,9 @@
 FROM php:8.3-cli
 WORKDIR /app
 COPY . /app
+COPY docker/entrypoint.sh /entrypoint.sh
 RUN apt-get update && apt-get install -y unzip libpq-dev git && docker-php-ext-install pdo_pgsql
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 RUN composer install --no-interaction --prefer-dist
-CMD php artisan serve --host 0.0.0.0 --port 8000
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/api/docker/entrypoint.sh
+++ b/api/docker/entrypoint.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+if [ -z "$APP_KEY" ]; then
+  echo ">>> APP_KEY missing – generating…"
+  php artisan key:generate --no-interaction
+fi
+php artisan migrate --force --no-interaction
+echo ">>> Starting Laravel on :${PORT:-8080}"
+exec php -d variables_order=EGPCS -S 0.0.0.0:${PORT:-8080} -t public router.php

--- a/api/router.php
+++ b/api/router.php
@@ -1,0 +1,11 @@
+<?php
+
+$uri = urldecode(
+    parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH)
+);
+
+if ($uri !== '/' && file_exists(__DIR__.'/public'.$uri)) {
+    return false;
+}
+
+require_once __DIR__.'/public/index.php';


### PR DESCRIPTION
## Summary
- auto-generate Laravel `APP_KEY` if missing at container start
- run migrations automatically
- launch PHP built-in webserver from entrypoint

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846919b423c8332b55c762a0c91f120